### PR TITLE
fix timestamps

### DIFF
--- a/packages/main/src/main/modules/timeago.js
+++ b/packages/main/src/main/modules/timeago.js
@@ -33,20 +33,20 @@ TimeAgo = function() {
   return $(this).each(function() {
     var self = this
     var $self = $(self)
-    var text = $self.text()
     var datetime = $self.attr('title') || null
 
     if (!datetime) {
       return
     }
 
-    datetime = moment(datetime)
+    datetime = moment.utc(datetime).local()
 
     if (!datetime.isValid()) {
       return
     }
 
-    $self.attr('title', text)
+    // format as 1. Januar 1970 00:00:00
+    $self.attr('title', datetime.format('LL, LTS'))
 
     updateTime($self, datetime)
 


### PR DESCRIPTION
Fixes https://github.com/serlo/athene2/issues/902 and https://github.com/serlo/athene2/issues/457 by explicitly parsing the date as utc and converting it to local for `dateTime.fromNow()` to work correctly.